### PR TITLE
Remove support for Title#fetch in Linux.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,4 @@ before_install:
 before_script:
   - sudo apt-get install -y ffmpeg
   - ffmpeg -hwaccels
-  - sudo apt-get install wmctrl
-
 script: xvfb-run --server-num=0.0 --server-args="-ac -screen 0 1024x768x24" bundle exec rake spec

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### 1.1.0 (TBD)
+* `Titles#fetch` will now raise a `NotImplementedError` when used in a 
+Linux or a macOS environment.
+
 ### 1.0.0 (2019-03-15)
 * Released first major version.
 * Now uses `ScreenRecorder` as top level module. `FFMPEG` is not directly 

--- a/README.md
+++ b/README.md
@@ -56,8 +56,6 @@ $ gem install screen-recorder
 
 #### 3. Require gem
 
-Require this gem in your project and start using the gem:
-
 ```ruby
 require 'screen-recorder'
 ```

--- a/lib/screen-recorder/titles.rb
+++ b/lib/screen-recorder/titles.rb
@@ -5,7 +5,7 @@ module ScreenRecorder
     # This is done to remove unusable titles and to match the Ffmpeg expected input format
     # for capturing specific windows.
     # For example, "Window Title: Google - Mozilla Firefox" becomes "Google - Mozilla Firefox".
-    FILTERED_TITLES = %r{^Window Title:( N/A|\s+)?}
+    FILTERED_TITLES = %r{^Window Title:( N/A|\s+)?}.freeze
 
     #
     # Returns a list of available window titles for the given application (process) name.
@@ -18,22 +18,11 @@ module ScreenRecorder
     # @since 1.0.0-beta4
     class WindowGrabber
       #
-      # Returns a cleaned up list of available window titles
-      # for the given application (process) name.
+      # Returns a list of available window titles for the given application (process) name.
       #
       def available_windows_for(application)
-        return windows_os_window(application) if OS.windows?
-        return linux_os_window(application) if OS.linux?
+        raise NotImplementedError, 'Only Microsoft Windows (gdigrab) supports window capture.' unless OS.windows?
 
-        raise NotImplementedError, 'Your OS is not supported.'
-      end
-
-      private
-
-      #
-      # Returns list of window titles in FFmpeg expected format when using Microsoft Windows
-      #
-      def windows_os_window(application)
         titles = `tasklist /v /fi "imagename eq #{application}.exe" /fo list | findstr  Window`
                    .split("\n")
                    .map { |i| i.gsub(FILTERED_TITLES, '') }
@@ -44,38 +33,17 @@ module ScreenRecorder
         titles
       end
 
-      #
-      # Returns list of window titles in FFmpeg expected format when using Linux
-      #
-      def linux_os_window(application)
-        ScreenRecorder.logger.warn 'Default capture device on Linux (x11grab) does not support window recording.'
-        raise DependencyNotFound, 'wmctrl is not installed. Run: sudo apt install wmctrl.' unless wmctrl_installed?
-
-        titles = `wmctrl -l | awk '{$3=""; $2=""; $1=""; print $0}'` # Returns all open windows
-                   .split("\n")
-                   .map(&:strip)
-                   .select { |t| t.match?(/#{application}/i) } # Narrow down to given application
-        raise Errors::ApplicationNotFound, "No open windows found for: #{application}" if titles.empty?
-
-        titles
-      end
-
-      #
-      # Returns true if wmctrl is installed
-      #
-      def wmctrl_installed?
-        !`which wmctrl`.empty? # "" when not found
-      end
+      private
 
       #
       # Prints a warning if the retrieved list of window titles does no include
       # the given application process name, which applications commonly do.
       #
       def warn_on_mismatch(titles, application)
-        unless titles.map(&:downcase).join(',').include? application.to_s
-          ScreenRecorder.logger.warn "Process name and window title(s) do not match: #{titles}"
-          ScreenRecorder.logger.warn "Please manually provide the displayed window title."
-        end
+        return if titles.map(&:downcase).join(',').include? application.to_s
+
+        ScreenRecorder.logger.warn "Process name and window title(s) do not match: #{titles}"
+        ScreenRecorder.logger.warn 'Please manually provide the displayed window title.'
       end
     end # class WindowGrabber
   end # module Windows

--- a/spec/screen-recorder/titles_spec.rb
+++ b/spec/screen-recorder/titles_spec.rb
@@ -6,6 +6,15 @@ require_relative '../spec_helper'
 if OS.windows? # Only gdigrab supports window capture
   RSpec.describe ScreenRecorder::Titles do
     describe '.fetch' do
+
+      if OS.linux? || OS.mac?
+        context 'we are using Linux or MacOS' do
+          it 'raises error when OS is not Microsoft Windows' do
+            expect { ScreenRecorder::Titles.fetch('firefox') }.to raise_error(NotImplementedError)
+          end
+        end
+      end
+
       context 'given application is Firefox' do
         let(:browser_process) { :firefox }
         let(:url) { 'https://google.com' }


### PR DESCRIPTION
Now raises a `NotImplementedError` when current OS is not Microsoft Windows.