### PR TITLE
Relax "os" gem version to minor level

### DIFF
--- a/screen-recorder.gemspec
+++ b/screen-recorder.gemspec
@@ -39,6 +39,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webdrivers', '~> 4.0'
 
   spec.add_runtime_dependency 'childprocess', '>= 1.0', '< 4.0' # Roughly match Selenium
-  spec.add_runtime_dependency 'os', '~> 1.0.0'
+  spec.add_runtime_dependency 'os', '~> 1.0'
   spec.add_runtime_dependency 'streamio-ffmpeg', '~> 3.0'
 end


### PR DESCRIPTION
The "os" gem compatibility means that 1.1 is fine to use with this gem. 

Closes: https://github.com/kapoorlakshya/screen-recorder/issues/96